### PR TITLE
Protected the config register writes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,4 @@ pip-log.txt
 
 # Mac crap
 .DS_Store
+*.cpp~

--- a/src/SparkFun_MiniGen.cpp
+++ b/src/SparkFun_MiniGen.cpp
@@ -77,6 +77,10 @@ void MiniGen::setMode(MODE newMode)
       configReg |=0x0000;
     break;
   }
+  
+  // Make sure to clear the top two bit to make sure we're writing the config register:
+  configReg &= ~0xC000;
+  
   SPIWrite(configReg); // Now write our shadow copy to the part.
 }
 
@@ -90,6 +94,10 @@ void MiniGen::selectFreqReg(FREQREG reg)
   if (reg == FREQ0) configReg &= ~0x0800;
   // Otherwise, set bit 11.
   else              configReg |= 0x0800;
+  
+  // Make sure to clear the top two bit to make sure we're writing the config register:
+  configReg &= ~0xC000;
+  
   SPIWrite(configReg);
 }
 
@@ -99,6 +107,10 @@ void MiniGen::selectPhaseReg(PHASEREG reg)
 {
   if (reg == PHASE0) configReg &= ~0x0400;
   else               configReg |= 0x0400;
+  
+  // Make sure to clear the top two bit to make sure we're writing the config register:
+  configReg &= ~0xC000;
+  
   SPIWrite(configReg);
 }
 
@@ -128,6 +140,10 @@ void MiniGen::setFreqAdjustMode(FREQADJUSTMODE newMode)
       configReg |= 0x2000;
     break;
   }
+  
+  // Make sure to clear the top two bit to make sure we're writing the config register:
+  configReg &= ~0xC000;
+  
   SPIWrite(configReg);
 }
 


### PR DESCRIPTION
This should make the writes of the config register work.  The MSB was getting set to '1' when it shouldn't be, which cause the config data to get written into FREQ1 register instead.
